### PR TITLE
Use slab.config.json to share theme and configuration

### DIFF
--- a/app/admin.php
+++ b/app/admin.php
@@ -22,3 +22,11 @@ add_action('customize_register', function (\WP_Customize_Manager $wp_customize) 
 add_action('customize_preview_init', function () {
     wp_enqueue_script('slab/customizer.js', asset_path('scripts/customizer.js'), ['customize-preview'], null, true);
 });
+
+/**
+ * Admin JS
+ */
+add_action('admin_enqueue_scripts', function () {
+    wp_enqueue_script('sage/admin', asset_path('scripts/admin.js'), [], null, true);
+    wp_localize_script('sage/admin', 'sageOptions', ['colors' => get_theme_colors()]);
+});

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -127,6 +127,40 @@ function locate_template($templates)
 }
 
 /**
+ * Return all the values from slab.config.json
+ *
+ * @return array
+ */
+function get_slab_config_json(): array
+{
+    if (!file_exists($themeJson = dirname(__DIR__) . '/slab.config.json')) {
+        return collect([]);
+    }
+
+    $config = json_decode(file_get_contents($themeJson), true);
+
+    // Set the slug to a sensible default if not configured
+    $config['theme']['colors'] = array_map(function ($color) {
+        $color['slug'] = $color['slug'] ?? sanitize_title($color['name']);
+        return $color;
+    }, $config['theme']['colors']);
+
+    return $config;
+}
+
+/**
+ * Get the colors defined in slab.config.json, optionally filtered
+ * by slab/theme/colors
+ *
+ * @return array
+ */
+function get_theme_colors(): array
+{
+    $config = get_slab_config_json();
+    return apply_filters('slab/theme/colors', $config['theme']['colors'] ?? []);
+}
+
+/**
  * Determine whether to show the sidebar
  * @return bool
  */

--- a/app/setup.php
+++ b/app/setup.php
@@ -70,6 +70,17 @@ add_action('after_setup_theme', function () {
      * @see resources/assets/styles/layouts/_tinymce.scss
      */
     add_editor_style(asset_path('styles/main.css'));
+
+    /**
+     * Define the main colors for Gutenberg editor
+     * @link https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes
+     */
+    if (!empty($colors = get_theme_colors())) :
+        add_theme_support(
+            'editor-color-palette',
+            apply_filters('slab/theme/colors', $colors)
+        );
+    endif;
 }, 20);
 
 /**

--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
     "extract-text-webpack-plugin": "~3.0.2",
     "file-loader": "^6.2.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
+    "husky": "^6.0.0",
     "imagemin-mozjpeg": "^9.0.0",
     "imagemin-webpack-plugin": "^2.4.2",
     "import-glob": "~1.5",
     "node-sass": "^5.0.0",
+    "node-sass-json-importer": "^4.3.0",
     "postcss-loader": "^4.0.4",
     "postcss-safe-parser": "^5.0.2",
     "resolve-url-loader": "^3.1.2",
@@ -70,8 +72,7 @@
     "webpack-dev-middleware": "~2.0.4",
     "webpack-hot-middleware": "^2.22.3",
     "webpack-merge": "~4.1.4",
-    "yargs": "^16.1.0",
-    "husky": "^6.0.0"
+    "yargs": "^16.1.0"
   },
   "dependencies": {
     "bootstrap": "^4.5.3",

--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -7,6 +7,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const CopyGlobsPlugin = require('copy-globs-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
+const SassJsonImporter = require('node-sass-json-importer');
 
 const desire = require('./util/desire');
 const config = require('./config');
@@ -94,6 +95,7 @@ let webpackConfig = {
               loader: 'sass', options: {
                 sourceMap: config.enabled.sourceMaps,
                 sourceComments: true,
+                importer: SassJsonImporter,
               },
             },
           ],

--- a/resources/assets/config.json
+++ b/resources/assets/config.json
@@ -1,20 +1,12 @@
 {
   "entry": {
-    "main": [
-      "./scripts/main.js",
-      "./styles/main.scss"
-    ],
-    "customizer": [
-      "./scripts/customizer.js"
-    ]
+    "main": ["./scripts/main.js", "./styles/main.scss"],
+    "customizer": ["./scripts/customizer.js"],
+    "admin": ["./scripts/admin.js"]
   },
   "publicPath": "/wp-content/themes/slab",
   "devUrl": "http://example.test",
   "proxyUrl": "http://localhost:3000",
   "cacheBusting": "[name]_[hash:8]",
-  "watch": [
-    "app/**/*.php",
-    "config/**/*.php",
-    "resources/views/**/*.php"
-  ]
+  "watch": ["app/**/*.php", "config/**/*.php", "resources/views/**/*.php"]
 }

--- a/resources/assets/scripts/admin.js
+++ b/resources/assets/scripts/admin.js
@@ -1,0 +1,11 @@
+/**
+ * ACF JS Hooks
+ *
+ * @link https://www.advancedcustomfields.com/resources/javascript-api/
+ */
+if (window.acf && window.slabOptions) {
+  window.acf.add_filter('color_picker_args', function (args) {
+    args.palettes = window.slabOptions.colors.map((obj) => obj.color);
+    return args;
+  });
+}

--- a/resources/assets/styles/common/_variables.scss
+++ b/resources/assets/styles/common/_variables.scss
@@ -1,5 +1,17 @@
 /** Import Bootstrap functions */
 @import "~bootstrap/scss/functions";
+@import "../../../../slab.config.json";
+
+$slab-colors: map-get($theme, "colors");
+
+@each $color in $slab-colors {
+  $slug: map-get($color, "slug");
+  $hex: map-get($color, "color");
+
+  .bg-#{$slug} {
+    background-color: $hex;
+  }
+}
 
 $theme-colors: (
   primary: #525ddc

--- a/slab.config.json
+++ b/slab.config.json
@@ -1,0 +1,11 @@
+{
+  "theme": {
+    "colors": [
+      {
+        "name": "Dark Blue",
+        "slug": "dark-blue",
+        "color": "#043f5e"
+      }
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,6 +5284,11 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
+is-there@^4.4.4:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/is-there/-/is-there-4.5.1.tgz#ea292e7fad3fc4d70763fe0af40a286c9f5e1e2e"
+  integrity sha512-vIZ7HTXAoRoIwYSsTnxb0sg9L6rth+JOulNcavsbskQkCIWoSM2cjFOWZs4wGziGZER+Xgs/HXiCQZgiL8ppxQ==
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -5496,6 +5501,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 json5@^2.1.2:
   version "2.1.3"
@@ -6336,6 +6348,15 @@ node-releases@^1.1.66:
   version "1.1.66"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz#609bd0dc069381015cd982300bae51ab4f1b1814"
   integrity sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==
+
+node-sass-json-importer@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-sass-json-importer/-/node-sass-json-importer-4.3.0.tgz#15773cc070f16aa20e93b378908366af85f6f742"
+  integrity sha512-+j+SsxPzYo7fWIDuz/etuLs+wfay5Zx2bkWE4LazkycdYGzEtCQz4tgIFXveeLBCBM6jvY4fp45z2JEj6U+VWQ==
+  dependencies:
+    is-there "^4.4.4"
+    json5 "^2.1.1"
+    lodash "^4.17.15"
 
 node-sass@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
The color scheme and possibly other theme values that we need to set for a given project generally need to be shared with the SCSS/CSS, Gutenberg editor and Advanced Custom Fields for a uniform experience. 

There isn't an easy way to supply these variables to all in an automated manner, but this PR takes a cue from Tailwind and makes use of a slab.config.json file that can be shared and read by PHP and SCSS (via Webpack plugin) to ensure that all aspect of the theme are using a central registry for theme config values.

Currently, this is an exploratory PR open for feedback and will require further testing before merge.