### PR TITLE
Update included Bootstrap to version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Slab is a WordPress starter theme based on the [Sage starter theme by Roots](htt
 - [Browsersync](http://www.browsersync.io/) for synchronized browser testing
 - [Blade](https://laravel.com/docs/5.6/blade) as a templating engine
 - [Controller](https://github.com/soberwp/controller) for passing data to Blade templates
-- [Bootstrap 4](https://getbootstrap.com/)
+- [Bootstrap 5](https://getbootstrap.com/)
 
 ## Requirements
 

--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -6,6 +6,30 @@ use Sober\Controller\Controller;
 
 class App extends Controller
 {
+    public function primaryMenu()
+    {
+        return [
+            'theme_location'  => 'primary_navigation',
+            'depth'           => 2, // 1 = no dropdowns, 2 = with dropdowns.
+            'container'       => null,
+            'items_wrap'      => '%3$s',
+            'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
+            'walker'          => new \WP_Bootstrap_Navwalker(),
+        ];
+    }
+
+    public function secondaryMenu()
+    {
+        return [
+            'theme_location'  => 'secondary_navigation',
+            'depth'           => 1, // 1 = no dropdowns, 2 = with dropdowns.
+            'container'       => null,
+            'items_wrap'      => '%3$s',
+            'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
+            'walker'          => new \WP_Bootstrap_Navwalker(),
+        ];
+    }
+
     public function siteName()
     {
         return get_bloginfo('name');

--- a/app/admin.php
+++ b/app/admin.php
@@ -20,5 +20,5 @@ add_action('customize_register', function (\WP_Customize_Manager $wp_customize) 
  * Customizer JS
  */
 add_action('customize_preview_init', function () {
-    wp_enqueue_script('slab/customizer.js', asset_path('scripts/customizer.js'), ['customize-preview'], null, true);
+    wp_enqueue_script('slab/customizer.js', asset_path('scripts/customizer.js'), ['customize-preview', 'jquery'], null, true);
 });

--- a/app/filters.php
+++ b/app/filters.php
@@ -57,7 +57,8 @@ add_filter('template_include', function ($template) {
         });
     });
     $data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {
-        return apply_filters("slab/template/{$class}/data", $data, $template);
+        $sageData = apply_filters("sage/template/{$class}/data", $data, $template);
+        return apply_filters("slab/template/{$class}/data", $sageData, $template);
     }, []);
     if ($template) {
         echo template($template, $data);
@@ -89,3 +90,18 @@ add_filter('comments_template', function ($comments_template) {
 
     return $comments_template;
 }, 100);
+
+/**
+ * Enable Boostrap 5 compatibility with WP Bootstrap Navwalker
+ *
+ * @link https://github.com/wp-bootstrap/wp-bootstrap-navwalker#usage-with-bootstrap-5
+ */
+add_filter('nav_menu_link_attributes', function ($atts, $item, $args) {
+    if (is_a($args->walker, 'WP_Bootstrap_Navwalker')) {
+        if (array_key_exists('data-toggle', $atts)) {
+            unset($atts['data-toggle']);
+            $atts['data-bs-toggle'] = 'dropdown';
+        }
+    }
+    return $atts;
+}, 20, 3);

--- a/app/setup.php
+++ b/app/setup.php
@@ -44,7 +44,8 @@ add_action('after_setup_theme', function () {
      * @link https://developer.wordpress.org/reference/functions/register_nav_menus/
      */
     register_nav_menus([
-        'primary_navigation' => __('Primary Navigation', 'slab')
+        'primary_navigation' => __('Primary Navigation', 'slab'),
+        'secondary_navigation' => __('Secondary Navigation', 'slab')
     ]);
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
       "homepage": "https://github.com/brianjohnhanna"
     }
   ],
-  "keywords": ["wordpress"],
+  "keywords": [
+    "wordpress"
+  ],
   "support": {
     "issues": "https://github.com/stirling-brandworks/slab/issues"
   },
@@ -26,7 +28,8 @@
     "roots/sage-lib": "~9.0.9",
     "soberwp/controller": "~2.1.0",
     "stoutlogic/acf-builder": "^1.11",
-    "log1x/blade-svg-sage": "^2.0"
+    "log1x/blade-svg-sage": "^2.0",
+    "wp-bootstrap/wp-bootstrap-navwalker": "^4.3"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8.0",
@@ -35,7 +38,9 @@
     "paulthewalton/acf-stubs": "^5.8"
   },
   "scripts": {
-    "test": ["phpcs"],
+    "test": [
+      "phpcs"
+    ],
     "post-create-project-cmd": [
       "Roots\\Sage\\Installer\\ComposerScript::postCreateProject"
     ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d10595f0bc86584645f944935737f9ca",
+    "content-hash": "a44ba46e138282584f8bf264696c318d",
     "packages": [
         {
             "name": "brain/hierarchy",
@@ -1659,6 +1659,47 @@
                 }
             ],
             "time": "2020-09-28T13:05:58+00:00"
+        },
+        {
+            "name": "wp-bootstrap/wp-bootstrap-navwalker",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-bootstrap/wp-bootstrap-navwalker.git",
+                "reference": "5d39044bcee8703d1402f7371b033c460b2e0a71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-bootstrap/wp-bootstrap-navwalker/zipball/5d39044bcee8703d1402f7371b033c460b2e0a71",
+                "reference": "5d39044bcee8703d1402f7371b033c460b2e0a71",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "require-dev": {
+                "stevegrunwell/wp-enforcer": "^0.5.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Brandon Hubbard"
+                },
+                {
+                    "name": "William Patton",
+                    "email": "will@pattonwebz.com"
+                }
+            ],
+            "description": "A custom WordPress nav walker class to fully implement the Bootstrap 4 navigation style in a custom theme using the WordPress built in menu manager.",
+            "support": {
+                "issues": "https://github.com/wp-bootstrap/wp-bootstrap-navwalker/issues/",
+                "source": "https://github.com/wp-bootstrap/wp-bootstrap-navwalker/"
+            },
+            "time": "2019-10-02T18:15:47+00:00"
         }
     ],
     "packages-dev": [

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "extract-text-webpack-plugin": "~3.0.2",
     "file-loader": "^6.2.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
+    "husky": "^6.0.0",
     "imagemin-mozjpeg": "^9.0.0",
     "imagemin-webpack-plugin": "^2.4.2",
     "import-glob": "~1.5",
@@ -70,12 +71,10 @@
     "webpack-dev-middleware": "~2.0.4",
     "webpack-hot-middleware": "^2.22.3",
     "webpack-merge": "~4.1.4",
-    "yargs": "^16.1.0",
-    "husky": "^6.0.0"
+    "yargs": "^16.1.0"
   },
   "dependencies": {
-    "bootstrap": "^4.5.3",
-    "jquery": "^3.3.1",
-    "popper.js": "^1.14.7"
+    "@popperjs/core": "^2.9.2",
+    "bootstrap": "^5.0.2"
   }
 }

--- a/resources/assets/build/webpack.config.js
+++ b/resources/assets/build/webpack.config.js
@@ -157,7 +157,7 @@ let webpackConfig = {
       $: 'jquery',
       jQuery: 'jquery',
       'window.jQuery': 'jquery',
-      Popper: 'popper.js/dist/umd/popper.js',
+      Popper: '@popperjs/core/dist/umd/popper.js',
     }),
     new webpack.LoaderOptionsPlugin({
       minimize: config.enabled.optimize,

--- a/resources/assets/config.json
+++ b/resources/assets/config.json
@@ -1,20 +1,11 @@
 {
   "entry": {
-    "main": [
-      "./scripts/main.js",
-      "./styles/main.scss"
-    ],
-    "customizer": [
-      "./scripts/customizer.js"
-    ]
+    "main": ["./scripts/main.js", "./styles/main.scss"],
+    "customizer": ["./scripts/customizer.js"]
   },
   "publicPath": "/wp-content/themes/slab",
-  "devUrl": "http://example.test",
+  "devUrl": "http://slab.local",
   "proxyUrl": "http://localhost:3000",
   "cacheBusting": "[name]_[hash:8]",
-  "watch": [
-    "app/**/*.php",
-    "config/**/*.php",
-    "resources/views/**/*.php"
-  ]
+  "watch": ["app/**/*.php", "config/**/*.php", "resources/views/**/*.php"]
 }

--- a/resources/assets/config.json
+++ b/resources/assets/config.json
@@ -4,7 +4,7 @@
     "customizer": ["./scripts/customizer.js"]
   },
   "publicPath": "/wp-content/themes/slab",
-  "devUrl": "http://example.local",
+  "devUrl": "http://example.test",
   "proxyUrl": "http://localhost:3000",
   "cacheBusting": "[name]_[hash:8]",
   "watch": ["app/**/*.php", "config/**/*.php", "resources/views/**/*.php"]

--- a/resources/assets/config.json
+++ b/resources/assets/config.json
@@ -4,7 +4,7 @@
     "customizer": ["./scripts/customizer.js"]
   },
   "publicPath": "/wp-content/themes/slab",
-  "devUrl": "http://slab.local",
+  "devUrl": "http://example.local",
   "proxyUrl": "http://localhost:3000",
   "cacheBusting": "[name]_[hash:8]",
   "watch": ["app/**/*.php", "config/**/*.php", "resources/views/**/*.php"]

--- a/resources/assets/scripts/customizer.js
+++ b/resources/assets/scripts/customizer.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 wp.customize('blogname', (value) => {
-  value.bind(to => $('.brand').text(to));
+  value.bind((to) => $('.brand').text(to));
 });

--- a/resources/assets/scripts/main.js
+++ b/resources/assets/scripts/main.js
@@ -1,8 +1,5 @@
-// import external dependencies
-import 'jquery';
-
 // Import everything from autoload
-import './autoload/**/*'
+import './autoload/**/*';
 
 // import local dependencies
 import Router from './util/Router';
@@ -21,4 +18,4 @@ const routes = new Router({
 });
 
 // Load Events
-jQuery(document).ready(() => routes.loadEvents());
+jQuery(document).on('ready', () => routes.loadEvents());

--- a/resources/assets/styles/common/_variables.scss
+++ b/resources/assets/styles/common/_variables.scss
@@ -1,10 +1,50 @@
-/** Import Bootstrap functions */
-@import "~bootstrap/scss/functions";
+/**
+ * Use this file to customize the bootstrap variables (colors, fonts, etc)
+ *
+ * Using the base _variables.scss file provided by Bootstrap, you can override any variables
+ * set in the original file by adding them below with the new value.
+ *
+ * @link https://getbootstrap.com/docs/5.0/customize/sass/#file-structure
+ * @link see https://github.com/twbs/bootstrap/blob/v5.0.2/scss/_variables.scss
+ */
 
-$theme-colors: (
-  primary: #525ddc
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+
+/* Colors */
+$primary: $blue;
+$secondary: $gray-600;
+$light: $gray-100;
+$dark: $gray-900;
+
+// Create your own map
+$custom-colors: (
+  "custom-color": #900,
 );
 
-/** Bootstrap navbar fix (https://git.io/fADqW) */
-$navbar-dark-toggler-icon-bg: none;
-$navbar-light-toggler-icon-bg: none;
+// Merge the maps
+$theme-colors: map-merge($theme-colors, $custom-colors);
+
+/* Body Colors */
+$body-bg: $white;
+$body-color: $gray-900;
+$link-color: $primary;
+$link-decoration: underline;
+$link-shade-percentage: 20%;
+$link-hover-color: shift-color($link-color, $link-shade-percentage);
+$link-hover-decoration: null;
+
+/* Typography */
+
+$font-family-sans-serif: system-ui, -apple-system, "Segoe UI", "Roboto",
+  "Helvetica Neue", "Arial", "Noto Sans", "Liberation Sans", sans-serif,
+  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$font-family-serif: "Georgia", serif;
+$font-family-base: $font-family-sans-serif;
+$headings-font-family: $font-family-serif;
+$h1-font-size: $font-size-base * 2.5;
+$h2-font-size: $font-size-base * 2;
+$h3-font-size: $font-size-base * 1.75;
+$h4-font-size: $font-size-base * 1.5;
+$h5-font-size: $font-size-base * 1.25;
+$h6-font-size: $font-size-base;

--- a/resources/assets/styles/components/_comments.scss
+++ b/resources/assets/styles/components/_comments.scss
@@ -6,10 +6,6 @@
   list-style: none;
 }
 
-.comment-form p {
-  @extend .form-group;
-}
-
 .comment-form input[type="text"],
 .comment-form input[type="email"],
 .comment-form input[type="url"],

--- a/resources/assets/styles/components/_forms.scss
+++ b/resources/assets/styles/components/_forms.scss
@@ -13,3 +13,244 @@
   @extend .btn;
   @extend .btn-secondary;
 }
+
+/**
+ * Gravity Forms BS5 Styling
+ *
+ * Adapted from https://mind.sh/are/how-to-style-gravity-forms-with-bootstrap-5/
+ */
+/* stylelint-disable no-descending-specificity */
+.gform_wrapper {
+  .gform_heading {
+    @extend .mb-3;
+
+    .gform_description {
+      @extend .lead;
+    }
+  }
+
+  .gform_validation_errors {
+    @extend .mt-3;
+    @extend .alert;
+    @extend .alert-danger;
+
+    h2 {
+      font-size: 1rem;
+      margin-bottom: 0;
+    }
+  }
+
+  legend.gfield_label {
+    font-size: 1.15rem;
+  }
+
+  .hidden_label label {
+    @extend .visually-hidden;
+  }
+
+  .gfield {
+    @extend .mb-3;
+  }
+
+  .gfield_label,
+  .ginput_container label {
+    @extend .form-label;
+  }
+
+  .gfield_error {
+    label.gfield_label {
+      color: $danger !important;
+    }
+
+    input,
+    select,
+    textarea {
+      border-color: $danger !important;
+    }
+
+    .validation_message {
+      color: $danger !important;
+      font-weight: bold !important;
+    }
+  }
+
+  .gf_left_half {
+    @include media-breakpoint-up(sm) {
+      float: left;
+      width: calc(50% - 10px);
+    }
+  }
+
+  .gf_right_half {
+    @include media-breakpoint-up(sm) {
+      float: right;
+      width: 50%;
+    }
+  }
+
+  .gfield_required {
+    margin-left: 0.15em;
+  }
+
+  .ginput_container {
+    input:not([type="checkbox"]):not([type="radio"]),
+    textarea,
+    .ginput_container_list,
+    .ginput_container_date {
+      @extend .form-control;
+    }
+  }
+
+  .gfield_select {
+    @extend .form-select;
+  }
+
+  .ginput_complex {
+    @extend .input-group;
+
+    input {
+      @extend .form-control;
+    }
+
+    &.gf_name_has_2 {
+      span {
+        display: block;
+        width: 50%;
+
+        &:first-child {
+          padding-right: 10px;
+        }
+      }
+    }
+
+    .ginput_full {
+      width: 100%;
+    }
+
+    .ginput_left {
+      width: 50%;
+      padding-right: 1%;
+    }
+
+    .ginput_right {
+      width: 50%;
+    }
+  }
+
+  .gfield_radio,
+  .gfield_checkbox {
+    li {
+      @extend .form-check;
+
+      padding: 0;
+      margin-left: 20px;
+      font-size: 1.1em;
+
+      input {
+        width: 0.8em;
+        height: 0.8em;
+
+        @extend .form-check-input;
+
+        margin-top: 4px;
+      }
+
+      label {
+        @extend .form-check-label;
+
+        margin: 3px;
+        padding: 0 0 0 25px;
+      }
+    }
+  }
+
+  .gform_body {
+    .gform_page_footer {
+      margin-top: 30px;
+
+      input.gform_button {
+        @extend .btn;
+        @extend .btn-primary;
+        @extend .btn-lg;
+      }
+
+      input.gform_previous_button,
+      input.gform_next_button {
+        @extend .btn;
+        @extend .btn-dark;
+        @extend .btn-lg;
+      }
+
+      input.gform_previous_button {
+        @extend .btn-sm;
+      }
+    }
+  }
+
+  .gform_footer {
+    text-align: right;
+
+    input.button {
+      @extend .btn;
+      @extend .btn-primary;
+      @extend .mt-2;
+    }
+  }
+
+  .gf_progressbar_wrapper {
+    .gf_progressbar {
+      @extend .progress;
+
+      .gf_progressbar_percentage {
+        @extend .progress-bar;
+        @extend .bg-success;
+      }
+    }
+  }
+}
+
+#ui-datepicker-div {
+  background: #fff;
+  padding: 10px;
+  font-size: 0.9em;
+  -webkit-box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.5);
+
+  .ui-datepicker-header {
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 0.8em;
+
+    .ui-datepicker-prev {
+      display: block;
+      width: 50%;
+    }
+
+    .ui-datepicker-next {
+      display: block;
+      width: 50%;
+      text-align: right;
+    }
+  }
+
+  .ui-datepicker-title {
+    width: 100%;
+    display: flex;
+
+    select {
+      @extend .form-select;
+
+      width: 50%;
+
+      &:first-child {
+        width: 49%;
+        margin-right: 1%;
+      }
+    }
+  }
+
+  table.ui-datepicker-calendar {
+    @extend .table;
+    @extend .table-sm;
+  }
+}

--- a/resources/assets/styles/components/_forms.scss
+++ b/resources/assets/styles/components/_forms.scss
@@ -1,10 +1,6 @@
 /** Search form */
-.search-form {
-  @extend .form-inline;
-}
-
 .search-form label {
-  @extend .form-group;
+  @extend .form-label;
 
   font-weight: normal;
 }

--- a/resources/assets/styles/components/_wp-classes.scss
+++ b/resources/assets/styles/components/_wp-classes.scss
@@ -51,6 +51,6 @@
 
 /** Text meant only for screen readers */
 .screen-reader-text {
-  @extend .sr-only;
-  @extend .sr-only-focusable;
+  @extend .visually-hidden;
+  @extend .visually-hidden-focusable;
 }

--- a/resources/assets/styles/main.scss
+++ b/resources/assets/styles/main.scss
@@ -13,6 +13,8 @@
 
 /** Import theme styles */
 @import "common/global";
+@import "common/typography";
+@import "common/utilities";
 @import "components/buttons";
 @import "components/comments";
 @import "components/forms";

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -48,6 +48,20 @@ if (!class_exists('Roots\\Sage\\Container')) {
 }
 
 /**
+ * Include the WP Bootstrap Navwalker manually. PSR Autoloading does not work
+ * @link https://github.com/wp-bootstrap/wp-bootstrap-navwalker
+ */
+if (!class_exists('WP_Bootstrap_Navwalker')) {
+    if (!file_exists($walker  = __DIR__ . '/../vendor/wp-bootstrap/wp-bootstrap-navwalker/class-wp-bootstrap-navwalker.php')) {
+        $sage_error(
+            __('The class-wp-bootstrap-navwalker.php file may be missing. Check your composer.json file.', 'slab'),
+            __('WP_Bootstrap_Navwalker not found.', 'slab')
+        );
+    }
+    require_once $walker;
+}
+
+/**
  * Sage required files
  *
  * The mapped array determines the code library included in your theme.

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -3,3 +3,59 @@
     @php dynamic_sidebar('sidebar-footer') @endphp
   </div>
 </footer>
+
+<footer class="text-center text-lg-start bg-light text-muted border-top">
+  <div class="container text-center text-md-start">
+    <div class="row mt-4">
+      <div class="col-md-3 col-lg-4 col-xl-3 mx-auto mb-4">
+        <h6 class="text-uppercase fw-bold mb-4">
+          {{ $site_name }}
+        </h6>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        </p>
+      </div>
+
+      <div class="col-md-2 col-lg-2 col-xl-2 mx-auto mb-4">
+        <h6 class="text-uppercase fw-bold mb-4">
+          Footer Menu 1
+        </h6>
+        <ul class="list-unstyled">
+          <li><a href="#!" class="text-reset">Link 1</a></li>
+          <li><a href="#!" class="text-reset">Link 2</a></li>
+          <li><a href="#!" class="text-reset">Link 3</a></li>
+          <li><a href="#!" class="text-reset">Link 4</a></li>
+        </ul>
+      </div>
+
+      <div class="col-md-3 col-lg-2 col-xl-2 mx-auto mb-4">
+        <h6 class="text-uppercase fw-bold mb-4">
+          Footer Menu 2
+        </h6>
+        <ul class="list-unstyled">
+          <li><a href="#!" class="text-reset">Link 1</a></li>
+          <li><a href="#!" class="text-reset">Link 2</a></li>
+          <li><a href="#!" class="text-reset">Link 3</a></li>
+          <li><a href="#!" class="text-reset">Link 4</a></li>
+        </ul>
+      </div>
+
+      <div class="col-md-4 col-lg-3 col-xl-3 mx-auto mb-md-0 mb-4">
+        <h6 class="text-uppercase fw-bold mb-4">
+          Contact
+        </h6>
+        <p class="mb-0">Boston, MA</p>
+        <p>
+          <a href="mailto:info@example.com" class="text-reset">info@example.com</a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="text-center p-3 small" style="background-color: rgba(0, 0, 0, 0.05);">
+    ©{{ date('Y') }} <a class="text-reset text-decoration-none" href="{{ home_url('/') }}">{{ $site_name }}</a> | Web
+    Design and
+    Development by <a href="https://stirlingbrandworks.com" class="text-reset text-decoration-none">Stirling
+      Brandworks</a>
+  </div>
+</footer>

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -1,10 +1,26 @@
-<header class="banner">
-  <div class="container">
-    <a class="brand" href="{{ home_url('/') }}">{{ get_bloginfo('name', 'display') }}</a>
-    <nav class="nav-primary">
-      @if (has_nav_menu('primary_navigation'))
-        {!! wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav']) !!}
-      @endif
-    </nav>
+@if (has_nav_menu('secondary_navigation'))
+<nav class="py-2 bg-light border-bottom">
+  <div class="container d-flex flex-wrap justify-content-end">
+    <ul class="nav">
+      {!! wp_nav_menu($secondary_menu) !!}
+    </ul>
   </div>
+</nav>
+@endif
+
+<header class="mb-4 border-bottom banner">
+  <nav class="navbar navbar-expand-lg navbar-light">
+    <div class="container">
+      <a class="navbar-brand" href="{{ home_url('/') }}">{{ $site_name }}</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarTogglerDemo02"
+        aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+          {!! wp_nav_menu($primary_menu) !!}
+        </ul>
+      </div>
+    </div>
+  </nav>
 </header>

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -1199,10 +1204,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
-  integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
+bootstrap@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.2.tgz#aff23d5e0e03c31255ad437530ee6556e78e728e"
+  integrity sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -5372,11 +5377,6 @@ jpegtran-bin@^4.0.0:
     bin-wrapper "^4.0.0"
     logalot "^2.0.0"
 
-jquery@^3.3.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
@@ -7053,11 +7053,6 @@ pngquant-bin@^5.0.0:
     bin-wrapper "^4.0.1"
     execa "^0.10.0"
     logalot "^2.0.0"
-
-popper.js@^1.14.7:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
-  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portscanner@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Todo

- [x] BS5 doesn't require jQuery anymore. We need to confirm whether we still need to include it in the theme, or can use WP's bundled version of jQuery to allow developers to use jQuery in their JS files.
- [x] Include/expand on recommended variables for override provided when setting up a new project
- [x] Confirm the search is properly formatted without the deprecated classes
- [x] Review [migration guide](https://getbootstrap.com/docs/5.0/migration/) for any outstanding items 
- [x] Confirm Gravity Forms outputs are Bootstrap 5

Resolves #5 