### PR TITLE
Update ACF to use return type of ID for any image fields

### DIFF
--- a/app/acf.php
+++ b/app/acf.php
@@ -30,14 +30,12 @@ add_filter('sober/controller/acf/array', function () {
 /**
  * Set the default return type for an image to be ID and not object
  *
- * @link https://www.advancedcustomfields.com/resources/acf-prepare_field/
+ * @link https://www.advancedcustomfields.com/resources/acf-load_field/
  */
 add_filter(
-    'acf/prepare_field/type=image',
+    'acf/load_field/type=image',
     function ($field) {
-        if (empty($field['return_format'])) {
-            $field['return_format'] = 'ID';
-        };
+        $field['return_format'] = 'ID';
         return $field;
     }
 );

--- a/app/fields/components/alert.php
+++ b/app/fields/components/alert.php
@@ -20,7 +20,6 @@ $fields
         'wrapper' => $config['wrapper']
     ])
     ->addImage('icon', [
-        'return_format' => 'ID',
         'wrapper' => $config['wrapper']
     ])
     ->addText('text', $config)->setRequired()

--- a/app/fields/components/button.php
+++ b/app/fields/components/button.php
@@ -7,9 +7,7 @@ use StoutLogic\AcfBuilder\FieldsBuilder;
 $fields = new FieldsBuilder('button');
 
 $fields
-    ->addImage('icon', [
-        'return_format' => 'ID'
-    ])
+    ->addImage('icon')
     ->addLink('link')->setRequired();
 
 return $fields;

--- a/app/fields/components/card.php
+++ b/app/fields/components/card.php
@@ -14,9 +14,7 @@ $fields
         ],
         'default_value' => 'vertical',
     ])
-    ->addImage('image', [
-        'return_format' => 'ID'
-    ])
+    ->addImage('image')
     ->addText('title')
     ->addTextarea('content')
     ->addLink('link');

--- a/app/fields/components/slider.php
+++ b/app/fields/components/slider.php
@@ -10,7 +10,6 @@ $fields
     ->addRepeater('slides')
     ->addImage('background_image', [
         'required' => true,
-        'return_format' => 'ID'
     ])
     ->addText('title')
     ->addTextarea('description')


### PR DESCRIPTION
To encourage use of the built-in WP functions for rendering and displaying images - which include lazy loading, SRC set, alt tags, icon support and more out of the box, we want to return the ID from all image fields used in ACF via the field builder.

This PR uses the [`load_field`](https://www.advancedcustomfields.com/resources/acf-load_field/) hook to ensure that the return type for any image fields is ID by default.