### PR TITLE
Add Prettier integration to linting tools

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,47 +1,45 @@
 module.exports = {
-  'root': true,
-  'extends': 'eslint:recommended',
-  'globals': {
-    'wp': true,
+  root: true,
+  extends: ["eslint:recommended", "prettier"],
+  globals: {
+    wp: true,
   },
-  'env': {
-    'node': true,
-    'es6': true,
-    'amd': true,
-    'browser': true,
-    'jquery': true,
+  env: {
+    node: true,
+    es6: true,
+    amd: true,
+    browser: true,
+    jquery: true,
   },
-  'parserOptions': {
-    'ecmaFeatures': {
-      'globalReturn': true,
-      'generators': false,
-      'objectLiteralDuplicateProperties': false,
-      'experimentalObjectRestSpread': true,
+  parserOptions: {
+    ecmaFeatures: {
+      globalReturn: true,
+      generators: false,
+      objectLiteralDuplicateProperties: false,
+      experimentalObjectRestSpread: true,
     },
-    'ecmaVersion': 2017,
-    'sourceType': 'module',
+    ecmaVersion: 2017,
+    sourceType: "module",
   },
-  'plugins': [
-    'import',
-  ],
-  'settings': {
-    'import/core-modules': [],
-    'import/ignore': [
-      'node_modules',
-      '\\.(coffee|scss|css|less|hbs|svg|json)$',
+  plugins: ["import"],
+  settings: {
+    "import/core-modules": [],
+    "import/ignore": [
+      "node_modules",
+      "\\.(coffee|scss|css|less|hbs|svg|json)$",
     ],
   },
-  'rules': {
-    'no-console': 0,
-    'quotes': ['error', 'single'],
-    'comma-dangle': [
-      'error',
+  rules: {
+    "no-console": 0,
+    quotes: ["error", "single"],
+    "comma-dangle": [
+      "error",
       {
-        'arrays': 'always-multiline',
-        'objects': 'always-multiline',
-        'imports': 'always-multiline',
-        'exports': 'always-multiline',
-        'functions': 'ignore',
+        arrays: "always-multiline",
+        objects: "always-multiline",
+        imports: "always-multiline",
+        exports: "always-multiline",
+        functions: "ignore",
       },
     ],
   },

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,10 +4,10 @@
   "trailingComma": "es5",
   "overrides": [
     {
-        "files": ["**/*.css", "**/*.scss", "**/*.html"],
-        "options": {
-            "singleQuote": false
-        }
+      "files": ["**/*.css", "**/*.scss", "**/*.html"],
+      "options": {
+        "singleQuote": false
+      }
     }
   ]
 }

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,12 +1,25 @@
 module.exports = {
-  'extends': 'stylelint-config-standard',
-  'rules': {
+  extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
+  rules: {
     'no-empty-source': null,
     'string-quotes': 'double',
+    'at-rule-empty-line-before': [
+      'always',
+      {
+        ignore: [
+          'after-comment',
+          'first-nested',
+          'inside-block',
+          'blockless-after-same-name-blockless',
+          'blockless-after-blockless',
+        ],
+        ignoreAtRules: ['else', 'warn', 'if', 'error'],
+      },
+    ],
     'at-rule-no-unknown': [
       true,
       {
-        'ignoreAtRules': [
+        ignoreAtRules: [
           'extend',
           'at-root',
           'debug',

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "sass-loader": "~6.0",
     "style-loader": "^0.23.1",
     "stylelint": "^13.7.2",
+    "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-webpack-plugin": "^0.10.5",
     "uglifyjs-webpack-plugin": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "css-loader": "^0.28.11",
     "cssnano": "^4.0.5",
     "eslint": "~4.19.1",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-import": "^2.14.0",
     "extract-text-webpack-plugin": "~3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9285,6 +9285,11 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+stylelint-config-prettier@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-8.0.2.tgz#da9de33da4c56893cbe7e26df239a7374045e14e"
+  integrity sha512-TN1l93iVTXpF9NJstlvP7nOu9zY2k+mN0NSFQ/VEGz15ZIP9ohdDZTtCWHs5LjctAhSAzaILULGbgiM0ItId3A==
+
 stylelint-config-recommended@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz#e0e547434016c5539fe2650afd58049a2fd1d657"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,6 +3287,11 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"


### PR DESCRIPTION
Adds Prettier integration with Stylelint and Eslint using the process described here: https://prettier.io/docs/en/integrating-with-linters.html

This provides a better development experience in IDEs that support Prettier formatting.