### PR TITLE
Fix issue with loading blocks from Slab config

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -167,7 +167,7 @@ add_action('init', function () {
 
         return file_exists($templatePath) && file_exists($fieldPath);
     })->map(function ($blockName) {
-        $field = require_once(config('theme.dir') . "/app/fields/components/$blockName.php");
+        $field = require(config('theme.dir') . "/app/fields/components/$blockName.php");
         if ($field instanceof FieldsBuilder) {
             $field->setLocation('block', '===', 'acf/' . $field->getName());
             acf_add_local_field_group($field->build());


### PR DESCRIPTION
`require_once` was returning true instead of the `FieldsBuilder` object because the file was already being required somewhere else in the boot process. 

This fixes the issue where the block fields wouldn't load, however it may be prudent to figure out where in the boot process the file is already being included, since it shouldn't be required unless explicitly specified. I didn't see an easy way to output this information so it may require some trial and error.