### PR TITLE
Update PHP formatting settings for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "dbaeumer.vscode-eslint",
     "bmewburn.vscode-intelephense-client",
     "esbenp.prettier-vscode",
-    "stylelint.vscode-stylelint"
+    "stylelint.vscode-stylelint",
+    "valeryanm.vscode-phpsab"
   ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "[php]": {
     "editor.formatOnSave": true,
     "editor.insertSpaces": true,
+    "editor.defaultFormatter": "valeryanm.vscode-phpsab"
   },
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
Changes the default formatter used in the VS Code workspace settings to one that implements PHPCBF and PHPCS

TODO

- Need to include instructions for setting up the plugin/dev environment. We either need to ensure PHPCS and PHPCBF are installed as composer devDependencies (easiest) or provide instructions for updating the settings for the plugin to point to global composer dependencies, since it didn't recognize them in my PATH. ([more info here](https://marketplace.visualstudio.com/items?itemName=ValeryanM.vscode-phpsab))
- Add Husky rule to ensure no PHPCS rules are disallowed on push. This will increase adoption and uniform code style but we'll have to make sure everyone on PHPStorm is also setup properly from the start. 
- Add any PHPCS rules relevant to Blade, and re-evaluate if we want to keep the blade formatter (onecentlin.laravel-blade) extension and should include in extensions.json or if the PHPCBF can handle it with appropriate configuration.
    - Note we can leave this plugin included for syntax highlighting and disable formatting with  `"blade.format.enable": false`

See #25 for more info