### PR TITLE
Fix bug with the unique accordion selector

### DIFF
--- a/resources/views/components/accordion.blade.php
+++ b/resources/views/components/accordion.blade.php
@@ -1,5 +1,5 @@
 @php
-$uniqid = uniqid();
+$uniqid = uniqid('accordion_');
 $items = array_map(
 function($item) { $item['slug'] = sanitize_title($item['title']); return $item; },
 $items


### PR DESCRIPTION
`uniqid` would often output alphanumeric strings that started with a number, which isn't a valid ID/selector in Javascript. This triggered some strange behavior with the accordion, notably that it required 2 clicks to open. By adding a prefix to `uniqid` this fixes the issue.